### PR TITLE
Task uplift

### DIFF
--- a/Frends.Community.Odbc/Frends.Community.Odbc.csproj
+++ b/Frends.Community.Odbc/Frends.Community.Odbc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;net471;net6.0;net8.0</TargetFrameworks>
     <authors>HiQ Finland</authors>
     <copyright>HiQ Finland</copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -9,7 +9,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.0</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
 
@@ -25,9 +25,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
-    <PackageReference Include="System.Data.Odbc" Version="5.0.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.Data.Odbc" Version="8.0.0" />
   </ItemGroup>
 
 </Project>
-

--- a/README.md
+++ b/README.md
@@ -120,3 +120,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 1.0.1 | Multitargeting .net standard 2.0, .net 471 |
 | 1.0.2 | Fixed version number conflict with Newtonsoft.Json  |
 | 1.1.0 | Release ODBC object pool after Task execution  |
+| 1.2.0 | Multitargeting added to .NET6 and .NET8. System.ComponentModel.Annotations updated to 5.0.0 and System.Data.Odbc updated to 8.0.0 |


### PR DESCRIPTION
Targeted to .NET6 and 8, and updated System.ComponentModel.Annotations to 5.0.0 and System.Data.Odbc to 8.0.0.

There is no workflow to test this on GitHub actions, neither a test ODBC to test on Frends, but local tests pass.
